### PR TITLE
Fix for backspace changing structure outside of MathQuill widget

### DIFF
--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -62,6 +62,16 @@
 				}
 			} );
 
+			// Fix for modifying previous content on pressing "Backspace" in Webkit and Gecko
+			// (due to ticket #13771 that workaround will be also needed there).
+			if ( CKEDITOR.env.webkit || CKEDITOR.env.gecko ) {
+				editor.on( 'key', function( evt ) {
+					if( evt.data.domEvent.getKey() === 8 && checkIfWidgetIsFocused( evt.editor ) ) {
+						evt.cancel();
+					}
+				} );
+			}
+
 			editor.widgets.add( 'mathQuill', {
 				allowedContent: 'span(!mathquill-widget)',
 				button: 'Insert Equation',


### PR DESCRIPTION
Turns out that the source of this problem was in a special code to [handle backspace for WebKits](http://dev.ckeditor.com/ticket/9998) as they were adding a lot of stray inline markup.

The easiest fix was simply to prevent this particular key from being processed by mentioned handler. Additionally you might notice that it's already doing this for Firefox (which was not mentioned in [mentioned source ticket](http://dev.ckeditor.com/ticket/9998)) - that's because we're just [about to use this handler for Firefox](http://dev.ckeditor.com/ticket/13771) too starting with 4.5.7.