### PR TITLE
Fix for backspace in / next to lists.

### DIFF
--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -62,15 +62,14 @@
 				}
 			} );
 
-			// Fix for modifying previous content on pressing "Backspace" in Webkit and Gecko
-			// (due to ticket #13771 that workaround will be also needed there).
-			if ( CKEDITOR.env.webkit || CKEDITOR.env.gecko ) {
-				editor.on( 'key', function( evt ) {
-					if( evt.data.domEvent.getKey() === 8 && checkIfWidgetIsFocused( evt.editor ) ) {
-						evt.cancel();
-					}
-				} );
-			}
+			// This fix prevents custom backspace handlers (like the one from #13771 or list backspace handler)
+			// from triggering.
+			editor.on( 'key', function( evt ) {
+				if ( evt.data.domEvent.getKey() === 8 && checkIfWidgetIsFocused( evt.editor ) ) {
+					evt.cancel();
+				}
+			}, null, null, 1 );
+
 
 			editor.widgets.add( 'mathQuill', {
 				allowedContent: 'span(!mathquill-widget)',


### PR DESCRIPTION
Fixes bugs on pressing backspace in lists and next to it.

## Example Test Cases

### TC1

1. open a multiple choice problem for editing
2. move cursor to the end of the last li, and press enter, starting a new list item
3. start a Mathquill span in the new, empty &lt;li&gt; and enter some text
4. press backspace and observe everything in the body of the editor being removed

### TC2

1. open a multiple choice problem for editing
2. move cursor to the end of the last li, and press enter twice, breaking you out of the &lt;li&gt; and starting a new, empty &lt;p&gt;
3. start a Mathquill span and enter some text
4. press backspace and observe everything in the body of the editor being removed