### PR TITLE
Passage editor

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,6 +16,12 @@
 		'indentlist',
 		'indentblock',
 		'widget',
+		'richcombo',
+		'floatpanel',
+		'listblock',
+		'panel',
+		'button',
+		'format',
 
 		'easbehaviors',
 		'easfontsize',
@@ -42,7 +48,8 @@
 		[ 'EASFontSize' ],
 		[ 'JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock', 'Indent', 'Outdent' ],
 		[ 'EASList'],
-		[ 'EASTable', 'EASImage', 'EASSpecials', '-', 'EASIntro', 'EASParBox', 'EASMathImages' ]
+		[ 'EASTable', 'EASImage', 'EASSpecials', '-', 'EASIntro', 'EASParBox', 'EASMathImages' ],
+		['Format'],
 	];
 
 	config.skin = 'kama';
@@ -51,4 +58,5 @@
     config.minimumChangeMilliseconds = 500;
     config.disableObjectResizing = true;
 	config.forcePasteAsPlainText = true;
+	config.format_tags = 'h1;h2;h3';
 };

--- a/config.js
+++ b/config.js
@@ -49,7 +49,6 @@
 		[ 'JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock', 'Indent', 'Outdent' ],
 		[ 'EASList'],
 		[ 'EASTable', 'EASImage', 'EASSpecials', '-', 'EASIntro', 'EASParBox', 'EASMathImages' ],
-		['Format'],
 	];
 
 	config.skin = 'kama';
@@ -58,5 +57,4 @@
     config.minimumChangeMilliseconds = 500;
     config.disableObjectResizing = true;
 	config.forcePasteAsPlainText = true;
-	config.format_tags = 'h1;h2;h3';
 };

--- a/config.js
+++ b/config.js
@@ -56,5 +56,5 @@
 	config.height = 400;
     config.minimumChangeMilliseconds = 500;
     config.disableObjectResizing = true;
-	config.forcePasteAsPlainText = true;
+	config.pasteFilter = 'plain-text';
 };

--- a/contents.css
+++ b/contents.css
@@ -700,4 +700,8 @@ img[data-eas-rotate="180"] {
 .unknown {
   display: none;
 }
+h3{
+  font-style: italic;
+  font-weight: normal;
+}
 

--- a/plugins/easbehaviors/plugin.js
+++ b/plugins/easbehaviors/plugin.js
@@ -197,6 +197,13 @@
 
   CKEDITOR.plugins.add('easbehaviors', {
     init: function(editor) {
+       var type;
+      if(typeof editor.config.easEditorType != 'undefined'){
+        type = editor.config.easEditorType;
+      }else{
+        type = "problem";
+      }
+
       editor.on('key', CKEDITOR.tools.bind(onKey, this));
       editor.on('change', CKEDITOR.tools.bind(onChange, this));
     }

--- a/plugins/easbehaviors/plugin.js
+++ b/plugins/easbehaviors/plugin.js
@@ -172,7 +172,7 @@
         });
       }
     }
-    if (evt.data.keyCode == 46 && range.checkEndOfBlock()) { // delete
+    else if (evt.data.keyCode == 46 && range.checkEndOfBlock()) { // delete
       // HACK sometimes calls to checkEndOfBlock (specifically the line that calls this.trim())
       // ends up deselecting what's currently selected. undo this.
       selection.selectRanges([range]);
@@ -192,18 +192,6 @@
           }
         });
       }
-    }else if(evt.data.keyCode == 13){
-      var specialClasses = ['source', 'author', 'title', 'subtitle', 'intro', 'copyr'];
-      setTimeout(function() { //ensures that enough time has passed that we get the new element not the element the enter originated from
-        var newElement = evt.editor.getSelection().getStartElement();
-        for(var i=0; i < specialClasses.length; i++){
-          if(newElement.hasClass(specialClasses[i]) == true){
-            newElement.removeAttribute("style");
-            newElement.removeClass(specialClasses[i]);
-          }
-        }
-      },10);
-      combo._.state = CKEDITOR.TRISTATE_OFF; //causes console error but also does what we want, which is to reset the stylescombo
     }
   }
 

--- a/plugins/easbehaviors/plugin.js
+++ b/plugins/easbehaviors/plugin.js
@@ -114,7 +114,7 @@
     }
 
     // ignore keystrokes that aren't backspace or delete or ctrl+x
-    if (evt.data.keyCode != 8 && evt.data.keyCode != 46 && evt.data.keyCode != (CKEDITOR.CTRL + 88)) {
+    if (evt.data.keyCode != 8 && evt.data.keyCode != 46 && evt.data.keyCode != (CKEDITOR.CTRL + 88) && evt.data.keyCode != 13) {
       console.log('ignore keystroke');
       return;
     }
@@ -172,7 +172,7 @@
         });
       }
     }
-    else if (evt.data.keyCode == 46 && range.checkEndOfBlock()) { // delete
+    if (evt.data.keyCode == 46 && range.checkEndOfBlock()) { // delete
       // HACK sometimes calls to checkEndOfBlock (specifically the line that calls this.trim())
       // ends up deselecting what's currently selected. undo this.
       selection.selectRanges([range]);
@@ -192,6 +192,17 @@
           }
         });
       }
+    }else if(evt.data.keyCode == 13){
+      var specialClasses = ['source', 'author', 'title', 'subtitle', 'intro', 'copyr'];
+      setTimeout(function() { //ensures that enough time has passed that we get the new element not the element the enter originated from
+        var newElement = evt.editor.getSelection().getStartElement();
+        for(var i=0; i < specialClasses.length; i++){
+          if(newElement.hasClass(specialClasses[i]) == true){
+            newElement.removeAttribute("style");
+            newElement.removeClass(specialClasses[i]);
+          }
+        }
+      },10);
     }
   }
 

--- a/plugins/easbehaviors/plugin.js
+++ b/plugins/easbehaviors/plugin.js
@@ -203,6 +203,7 @@
           }
         }
       },10);
+      combo._.state = CKEDITOR.TRISTATE_OFF; //causes console error but also does what we want, which is to reset the stylescombo
     }
   }
 

--- a/plugins/easimage/dialog.js
+++ b/plugins/easimage/dialog.js
@@ -387,8 +387,8 @@ function createBranchLi(node) {
 
 })();
 
-function getProperties(browser) {
-  var selectedThumbEl = $(browser).down('.multi .thumbnail.selected');
+function getProperties() {
+  var selectedThumbEl = $('browser').down('.multi .thumbnail.selected') || $('browser2').down('.multi .thumbnail.selected');
   if (!selectedThumbEl) {
     return null;
   }

--- a/plugins/easimage/plugin.js
+++ b/plugins/easimage/plugin.js
@@ -57,19 +57,15 @@
             }
 
             var iframe = $(args.sender.parts.dialog.$).down('iframe');
-            var properties = iframe.contentWindow.getProperties('browser');
-            var properties2 = iframe.contentWindow.getProperties('browser2');
+            var properties = iframe.contentWindow.getProperties();
 
-            if (!properties && !properties2) {
+            if (!properties) {
               return;
             }
 
             // insert new image
             if (properties){
               var image = createImage(editor, properties);
-              editor.insertElement(image);
-            }else if(properties2){
-              var image = createImage(editor, properties2);
               editor.insertElement(image);
             }
           }

--- a/plugins/easlistcustom/plugin.js
+++ b/plugins/easlistcustom/plugin.js
@@ -63,13 +63,14 @@
 					group: menuGroup,
 					command: 'emceelist'
 				};
-			}
 
-			uiMenuItems.easSubparts = {
-				label: 'Subparts',
-				group: menuGroup,
-				command: 'subpartlist'
-			};
+				uiMenuItems.easSubparts = {
+					label: 'Subparts',
+					group: menuGroup,
+					command: 'subpartlist'
+				};
+
+			}
 
 			uiMenuItems.easNone = {
 				label: 'None',
@@ -100,7 +101,6 @@
 							easUpperRoman: CKEDITOR.TRISTATE_OFF,
 							easLowerRoman: CKEDITOR.TRISTATE_OFF,
 							easBullets: CKEDITOR.TRISTATE_OFF,
-							easSubparts: CKEDITOR.TRISTATE_OFF,
 							easNone: CKEDITOR.TRISTATE_OFF
 						};
 					}else{

--- a/plugins/easlistcustom/plugin.js
+++ b/plugins/easlistcustom/plugin.js
@@ -8,14 +8,15 @@
 			var menuGroup = 'easlist',
 				uiMenuItems = {},
 				command;
-
 			command = editor.addCommand( 'numberlist', listCommand( 'numberlist', 'decimal' ) );
 			editor.addCommand( 'upperalphalist', listCommand( 'upperalphalist', 'upper-alpha' ) );
 			editor.addCommand( 'loweralphalist', listCommand( 'loweralphalist', 'lower-alpha' ) );
 			editor.addCommand( 'upperromanlist', listCommand( 'upperromanlist', 'upper-roman' ) );
 			editor.addCommand( 'lowerromanlist', listCommand( 'lowerromanlist', 'lower-roman' ) );
 			editor.addCommand( 'bulletslist', listCommand( 'bulletslist', 'disc' ) );
-			editor.addCommand( 'emceelist', listCommand( 'emceelist', 'emcee' ) );
+			if(editor.config.easEditorType == undefined){
+				editor.addCommand( 'emceelist', listCommand( 'emceelist', 'emcee' ) );
+			}
 			editor.addCommand( 'subpartlist', listCommand( 'subpartlist', 'subparts' ) );
 			editor.addCommand( 'nolist', listCommand( 'nolist', 'none' ) );
 
@@ -56,12 +57,13 @@
 				group: menuGroup,
 				command: 'bulletslist'
 			};
-
-			uiMenuItems.easEmcee = {
-				label: 'Multiple-Choice Block',
-				group: menuGroup,
-				command: 'emceelist'
-			};
+			if(editor.config.easEditorType == undefined){
+				uiMenuItems.easEmcee = {
+					label: 'Multiple-Choice Block',
+					group: menuGroup,
+					command: 'emceelist'
+				};
+			}
 
 			uiMenuItems.easSubparts = {
 				label: 'Subparts',
@@ -90,17 +92,30 @@
 				},
 
 				onMenu: function() {
-					return {
-						easNumber: CKEDITOR.TRISTATE_OFF,
-						easUpperAlpha: CKEDITOR.TRISTATE_OFF,
-						easLowerAlpha: CKEDITOR.TRISTATE_OFF,
-						easUpperRoman: CKEDITOR.TRISTATE_OFF,
-						easLowerRoman: CKEDITOR.TRISTATE_OFF,
-						easBullets: CKEDITOR.TRISTATE_OFF,
-						easEmcee: CKEDITOR.TRISTATE_OFF,
-						easSubparts: CKEDITOR.TRISTATE_OFF,
-						easNone: CKEDITOR.TRISTATE_OFF
-					};
+					if(editor.config.easEditorType == "passage"){
+						return {
+							easNumber: CKEDITOR.TRISTATE_OFF,
+							easUpperAlpha: CKEDITOR.TRISTATE_OFF,
+							easLowerAlpha: CKEDITOR.TRISTATE_OFF,
+							easUpperRoman: CKEDITOR.TRISTATE_OFF,
+							easLowerRoman: CKEDITOR.TRISTATE_OFF,
+							easBullets: CKEDITOR.TRISTATE_OFF,
+							easSubparts: CKEDITOR.TRISTATE_OFF,
+							easNone: CKEDITOR.TRISTATE_OFF
+						};
+					}else{
+						return {
+							easNumber: CKEDITOR.TRISTATE_OFF,
+							easUpperAlpha: CKEDITOR.TRISTATE_OFF,
+							easLowerAlpha: CKEDITOR.TRISTATE_OFF,
+							easUpperRoman: CKEDITOR.TRISTATE_OFF,
+							easLowerRoman: CKEDITOR.TRISTATE_OFF,
+							easBullets: CKEDITOR.TRISTATE_OFF,
+							easEmcee: CKEDITOR.TRISTATE_OFF,
+							easSubparts: CKEDITOR.TRISTATE_OFF,
+							easNone: CKEDITOR.TRISTATE_OFF
+						};
+					}
 				}
 			} );
 

--- a/plugins/format/lang/en-au.js
+++ b/plugins/format/lang/en-au.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'format', 'en-au', {
-	label: 'Format',
+	label: 'Heading',
 	panelTitle: 'Paragraph Format',
 	tag_address: 'Address',
 	tag_div: 'Normal (DIV)',

--- a/plugins/format/lang/en-ca.js
+++ b/plugins/format/lang/en-ca.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'format', 'en-ca', {
-	label: 'Format',
+	label: 'Heading',
 	panelTitle: 'Paragraph Format',
 	tag_address: 'Address',
 	tag_div: 'Normal (DIV)',

--- a/plugins/format/lang/en-gb.js
+++ b/plugins/format/lang/en-gb.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'format', 'en-gb', {
-	label: 'Format',
+	label: 'Heading',
 	panelTitle: 'Paragraph Format',
 	tag_address: 'Address',
 	tag_div: 'Normal (DIV)',

--- a/plugins/format/lang/en.js
+++ b/plugins/format/lang/en.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'format', 'en', {
-	label: 'Format',
+	label: 'Heading',
 	panelTitle: 'Paragraph Format',
 	tag_address: 'Address',
 	tag_div: 'Normal (DIV)',

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -56,7 +56,7 @@ CKEDITOR.plugins.add( 'format', {
 					var label = lang[ 'tag_' + tag ];
 
 					// Add the tag entry to the panel list.
-					this.add( tag, styles[ tag ].buildPreview( label ), label );
+					this.add( tag, label, label );
 				}
 			},
 

--- a/plugins/format/plugin.js
+++ b/plugins/format/plugin.js
@@ -39,18 +39,18 @@ CKEDITOR.plugins.add( 'format', {
 
 		editor.ui.addRichCombo( 'Format', {
 			label: lang.label,
-			title: lang.panelTitle,
+			//title: lang.panelTitle,
 			toolbar: 'styles,20',
 			allowedContent: allowedContent,
 
 			panel: {
 				css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 				multiSelect: false,
-				attributes: { 'aria-label': lang.panelTitle }
+				//attributes: { 'aria-label': lang.panelTitle }
 			},
 
 			init: function() {
-				this.startGroup( lang.panelTitle );
+				//this.startGroup( lang.panelTitle );
 
 				for ( var tag in styles ) {
 					var label = lang[ 'tag_' + tag ];

--- a/plugins/stylescombo/lang/en-au.js
+++ b/plugins/stylescombo/lang/en-au.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'stylescombo', 'en-au', {
-	label: 'Styles',
+	label: 'Style',
 	panelTitle: 'Formatting Styles', // MISSING
 	panelTitle1: 'Block Styles',
 	panelTitle2: 'Inline Styles',

--- a/plugins/stylescombo/lang/en-ca.js
+++ b/plugins/stylescombo/lang/en-ca.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'stylescombo', 'en-ca', {
-	label: 'Styles',
+	label: 'Style',
 	panelTitle: 'Formatting Styles', // MISSING
 	panelTitle1: 'Block Styles',
 	panelTitle2: 'Inline Styles',

--- a/plugins/stylescombo/lang/en-gb.js
+++ b/plugins/stylescombo/lang/en-gb.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'stylescombo', 'en-gb', {
-	label: 'Styles',
+	label: 'Style',
 	panelTitle: 'Formatting Styles',
 	panelTitle1: 'Block Styles',
 	panelTitle2: 'Inline Styles',

--- a/plugins/stylescombo/lang/en.js
+++ b/plugins/stylescombo/lang/en.js
@@ -3,7 +3,7 @@ Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
 For licensing, see LICENSE.md or http://ckeditor.com/license
 */
 CKEDITOR.plugins.setLang( 'stylescombo', 'en', {
-	label: 'Styles',
+	label: 'Style',
 	panelTitle: 'Formatting Styles',
 	panelTitle1: 'Block Styles',
 	panelTitle2: 'Inline Styles',

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -61,14 +61,14 @@
 
 			editor.ui.addRichCombo( 'Styles', {
 				label: lang.label,
-				//title: lang.panelTitle,
+				//title: lang.panelTitle, // EAS commented, don't want panel title for style groups
 				toolbar: 'styles,10',
 				allowedContent: allowedContent,
 
 				panel: {
 					css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 					multiSelect: true,
-					//attributes: { 'aria-label': lang.panelTitle }
+					//attributes: { 'aria-label': lang.panelTitle } EAS commented, don't want labels for style groups
 				},
 
 				init: function() {
@@ -82,11 +82,11 @@
 						type = style._.type;
 
 						if ( type != lastType ) {
-							//this.startGroup( lang[ 'panelTitle' + String( type ) ] );
+							//this.startGroup( lang[ 'panelTitle' + String( type ) ] ); // EAS don't want labels for style groups
 							lastType = type;
 						}
 
-						this.add( styleName, style.type == CKEDITOR.STYLE_OBJECT ? styleName : style.buildPreview(), styleName );
+						this.add( styleName, styleName, styleName ); // EAS changed: we don't want drop down to be preview of style applied
 					}
 
 					this.commit();
@@ -150,14 +150,14 @@
 							this.mark( name );
 					}
 
-					/*if ( !counter[ CKEDITOR.STYLE_BLOCK ] )
+					if ( !counter[ CKEDITOR.STYLE_BLOCK ] )
 						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_BLOCK ) ] );
 
 					if ( !counter[ CKEDITOR.STYLE_INLINE ] )
 						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_INLINE ) ] );
 
 					if ( !counter[ CKEDITOR.STYLE_OBJECT ] )
-						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_OBJECT ) ] );*/
+						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_OBJECT ) ] );
 				},
 
 				refresh: function() {

--- a/plugins/stylescombo/plugin.js
+++ b/plugins/stylescombo/plugin.js
@@ -61,14 +61,14 @@
 
 			editor.ui.addRichCombo( 'Styles', {
 				label: lang.label,
-				title: lang.panelTitle,
+				//title: lang.panelTitle,
 				toolbar: 'styles,10',
 				allowedContent: allowedContent,
 
 				panel: {
 					css: [ CKEDITOR.skin.getPath( 'editor' ) ].concat( config.contentsCss ),
 					multiSelect: true,
-					attributes: { 'aria-label': lang.panelTitle }
+					//attributes: { 'aria-label': lang.panelTitle }
 				},
 
 				init: function() {
@@ -82,7 +82,7 @@
 						type = style._.type;
 
 						if ( type != lastType ) {
-							this.startGroup( lang[ 'panelTitle' + String( type ) ] );
+							//this.startGroup( lang[ 'panelTitle' + String( type ) ] );
 							lastType = type;
 						}
 
@@ -150,14 +150,14 @@
 							this.mark( name );
 					}
 
-					if ( !counter[ CKEDITOR.STYLE_BLOCK ] )
+					/*if ( !counter[ CKEDITOR.STYLE_BLOCK ] )
 						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_BLOCK ) ] );
 
 					if ( !counter[ CKEDITOR.STYLE_INLINE ] )
 						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_INLINE ) ] );
 
 					if ( !counter[ CKEDITOR.STYLE_OBJECT ] )
-						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_OBJECT ) ] );
+						this.hideGroup( lang[ 'panelTitle' + String( CKEDITOR.STYLE_OBJECT ) ] );*/
 				},
 
 				refresh: function() {

--- a/skins/kama/panel.css
+++ b/skins/kama/panel.css
@@ -143,13 +143,16 @@ is its visual representation:
    to display a real name of the property which is visible for an end-user. */
 .cke_panel_listItem a
 {
-	padding: 2px;
+	padding-top: 2px;
+	padding-right: 2px;
+	padding-bottom: 2px;
 	display: block;
 	border: 1px solid #fff;
 	color: inherit !important;
 	text-decoration: none;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	padding-left: 30px;
 }
 
 /* IE6 */
@@ -173,9 +176,15 @@ is its visual representation:
 	/*border: 1px solid #ccc;*/
 	background-color: #d3d3d3;
 }
-.cke_panel_listItem.cke_selected a:after {
+.cke_panel_listItem.cke_selected a:before {
 	content: '\2713';
-	float: right;
+	background-color: #d3d3d3;
+	margin-left: -20px;
+	padding-right: 6px;
+}
+
+.cke_panel_listItem a:hover:before{
+	background-color: #dff1ff;
 }
 
 .cke_panel_listItem a:hover,

--- a/skins/kama/panel.css
+++ b/skins/kama/panel.css
@@ -170,8 +170,12 @@ is its visual representation:
 
 .cke_panel_listItem.cke_selected a
 {
-	border: 1px solid #ccc;
-	background-color: #e9f5ff;
+	/*border: 1px solid #ccc;*/
+	background-color: #d3d3d3;
+}
+.cke_panel_listItem.cke_selected a:after {
+	content: '\2713';
+	float: right;
 }
 
 .cke_panel_listItem a:hover,

--- a/skins/kama/panel.css
+++ b/skins/kama/panel.css
@@ -171,10 +171,13 @@ is its visual representation:
 	color: #000;
 }
 
+.cke_panel_listItem.cke_selected{
+	background-color: #d3d3d3 !important;
+}
+
 .cke_panel_listItem.cke_selected a
 {
-	/*border: 1px solid #ccc;*/
-	background-color: #d3d3d3;
+	background-color: #d3d3d3 !important;
 }
 .cke_panel_listItem.cke_selected a:before {
 	content: '\2713';


### PR DESCRIPTION
This PR contains changes for allowing a separate configuration of the editor (with some small behavioral changes) without duplicating the editor code.

To make this possible, we include additional CKEditor plugins needed for style and header menu items in the Passage version of the editor, we include different configuration for the Passage and Problem versions of the editor, and we change slightly some behavior in eas custom plugins for the passage editor.