### PR TITLE
Add \lin command to mathquill (change mathquill.min.js version number)

### DIFF
--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -36,7 +36,7 @@
 				editor.addContentsCss( mathQuillPath + 'mathquill.css' );
 			}
 
-			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.2', function( result ) {
+			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.3', function( result ) {
 				if ( !result ) {
 					console.error( 'Could not fetch MathQuill script.' );
 				}


### PR DESCRIPTION
This only changes the version number of mathquill.min.js in order to cache-bust a mathquill update that adds the \lin command.