### PR TITLE
Update mathquill javascript version for cache-bust

### DIFF
--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -36,7 +36,7 @@
 				editor.addContentsCss( mathQuillPath + 'mathquill.css' );
 			}
 
-			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.3', function( result ) {
+			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.4', function( result ) {
 				if ( !result ) {
 					console.error( 'Could not fetch MathQuill script.' );
 				}


### PR DESCRIPTION
This PR changes the query string in ckeditor that includes mathquill.min.js, which just got updated to add some more math commands.