### PR TITLE
Remove curly braces as they are typed in advanced dialogs

### DIFF
--- a/plugins/easproperties/dialogs.js
+++ b/plugins/easproperties/dialogs.js
@@ -196,6 +196,10 @@ function setupInput(element, texProp){
     $(easPrefix + key + "-label").up().insert(elem);
   }
 
+  // remove curly braces, if entered
+  elem.observe("keyup", function(){
+    $(this).setValue($(this).getValue().replace(/[{}]/g, ""));
+  });
 }
 
 function setPropertyTextbox(element, texProp){


### PR DESCRIPTION
Curly braces should now be removed as typed from advanced dialogs, as they should never be entered for TeX.