### PR TITLE
Update mathquill version number for cache bust

### DIFF
--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -29,14 +29,13 @@
 
 		init: function( editor ) {
 			var path = this.path,
-				mathQuillPath = path + '../../../mathquill/',
 				MATHQUILL_KEYSTROKE = CKEDITOR.CTRL + 77; // CTRL + M
 
 			if ( editor.addContentsCss ) {
-				editor.addContentsCss( mathQuillPath + 'mathquill.css' );
+				editor.addContentsCss( '/assets/mathquill.css' );
 			}
 
-			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.6', function( result ) {
+			CKEDITOR.scriptLoader.load( '/assets/mathquill/mathquill.min.js?v2.6', function( result ) {
 				if ( !result ) {
 					console.error( 'Could not fetch MathQuill script.' );
 				}

--- a/plugins/mathquill/plugin.js
+++ b/plugins/mathquill/plugin.js
@@ -36,7 +36,7 @@
 				editor.addContentsCss( mathQuillPath + 'mathquill.css' );
 			}
 
-			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.5', function( result ) {
+			CKEDITOR.scriptLoader.load( mathQuillPath + 'mathquill.min.js?v2.6', function( result ) {
 				if ( !result ) {
 					console.error( 'Could not fetch MathQuill script.' );
 				}


### PR DESCRIPTION
This updates the mathquill query string version number for cache busting (for https://github.com/educaide/mathquill/pull/3)

This should be deployed with the student-mathquill update (https://github.com/educaide/hachiko/pull/991) since it now looks for mathquill.js and mathquill.css in different paths now.

@gcortright Ready for review