### PR TITLE
compare against Iterator also

### DIFF
--- a/core/tools.js
+++ b/core/tools.js
@@ -267,7 +267,7 @@
 		 * @returns {Boolean} `true` if the object is an Array, otherwise `false`.
 		 */
 		isArray: function( object ) {
-			return Object.prototype.toString.call( object ) == '[object Array]';
+			return Object.prototype.toString.call( object ) == '[object Array]' || Object.prototype.toString.call( object )  == '[object Array Iterator]';
 		},
 
 		/**


### PR DESCRIPTION
Fixes the `isArray` function so that it will work with ES6 style prototype signature. Note, this probably isn't the _right_ way to do things, but it at least works.