### PR TITLE
Add option to insert image in editor after upload

### DIFF
--- a/plugins/easimage/dialog.css
+++ b/plugins/easimage/dialog.css
@@ -3,6 +3,10 @@ body, td {
   font-size: 12px;
 }
 
+.upload-option {
+  margin-top: 10px;
+}
+
 .close-preview-button{
   position: absolute;
   left: 725px;

--- a/plugins/easimage/dialog.html
+++ b/plugins/easimage/dialog.html
@@ -89,6 +89,13 @@
           </form>
         </p>
 
+        <div class="upload-option">
+          <input name="uploading-multiple" id="uploading-multiple" type="hidden"/>
+          <input name="add-after-upload" id="add-after-upload" type="checkbox" checked="checked">
+            <label for="add-after-upload">Insert image after single file upload</label>
+          </input>
+        </div>
+
         <h3 style="font-size: 14px; font-weight: bold;  margin-top: 10px; margin-bottom: 10px">Requirements:</h3>
         <ul style="margin-left: 15px">
           <li style="padding: 5px; list-style: disc">Image format must be png, jpg or jpeg.</li>

--- a/plugins/easimage/plugin.js
+++ b/plugins/easimage/plugin.js
@@ -3,27 +3,6 @@
 (function() {
   'use strict';
 
-  function createImage(editor, properties) {
-
-    // Setting the width and height directly is necessary becuase otherwise the browser displays 1px of our low quality thumbnail = 1px on the screen, which we do not want.
-    var inch_width  = properties.width  / properties.dpi;
-    var inch_height = properties.height / properties.dpi;
-    var style = "";
-    style += "width:  " + inch_width  + "in;";
-    style += "height: " + inch_height + "in;";
-
-    var imgElem = editor.document.createElement('img');
-    imgElem.setAttribute('src', properties.src);
-    imgElem.setAttribute('alt', properties.filename);
-    imgElem.setAttribute('hasProperties', true);
-    imgElem.setAttribute('style', style);
-    imgElem.data('width', properties.width);
-    imgElem.data('height', properties.height);
-    imgElem.data('dpi', properties.dpi);
-
-    return imgElem;
-  }
-
   CKEDITOR.plugins.add('easimage', {
     requires: 'iframedialog',
     icons: 'easimage',
@@ -81,7 +60,7 @@
 
             // insert new image
             if (properties){
-              var image = createImage(editor, properties);
+              var image = iframe.contentWindow.createImage(editor, properties);
               editor.insertElement(image);
             }
           }


### PR DESCRIPTION
Don't merge yet, because the styling, etc. should be looked over first. Makes it so if you want multiple images in your problem, you don't have to keep uploading, selecting "ok", and re-opening the dialog over and over.

Note: `this.reset()` was causing an error, so taking it out for now. From googling, it looks like `reset` is an event, not a function.

![sn](https://user-images.githubusercontent.com/16353861/38116141-b44a6db8-3363-11e8-8d7b-98d0370ececb.png)